### PR TITLE
Don't Panic!

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -19,8 +19,14 @@ type Builder[T Config] struct {
 	setProps     map[string]bool
 }
 
-func (b *Builder[T]) Build() (T, error) {
-	var err error
+func (b *Builder[T]) Build() (cfg T, err error) {
+
+	// Don't Panic!
+	defer func() {
+		if panicErr := recover(); panicErr != nil {
+			err = fmt.Errorf("builder panic:  %v", panicErr)
+		}
+	}()
 
 	err = b.instantiateCfg()
 	if err != nil {

--- a/builder_error_test.go
+++ b/builder_error_test.go
@@ -30,3 +30,18 @@ func TestConfigBuilderErrors(t *testing.T) {
 		assert.Equal(t, tst.expected, err.Error())
 	}
 }
+
+func TestConfigBuilderHandlePanic(t *testing.T) {
+
+	os.Setenv("MY_UINT", "42")
+
+	b := Builder[*TestConfig]{}
+
+	// put Builder into a bad internal state to force a panic
+	b.instantiated = true
+
+	_, err := b.Build()
+	assert.Error(t, err)
+	assert.Equal(t, "builder panic:  reflect: call of reflect.Value.Field on zero Value", err.Error())
+
+}


### PR DESCRIPTION
If things go pear-shaped and a panic occurs when trying to run Build(), catch the panic and return an error instead.