### PR TITLE
Add inital PrefixFallback implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Here are the options that can be set on a Builder:
 | KeyValueSeparator | :       | splits keys and values for maps                            |
 | TagKey            | envvar  | used to identify tag values used by cfgbuild for a field   |
 | Uint8Lists        | false   | when set to true it designates that []uint8 and []byte should be treated as a list (ie 1,2,3,4) instead of as a series of bytes |
+| PrefixFallback    | false   | when set to true lookups will first try "PREFIX_name" and if there isn't any environment variable with "PREFIX_name" it will fall back to just "name" |
 
 
 

--- a/builder_prefix_fallback_test.go
+++ b/builder_prefix_fallback_test.go
@@ -1,0 +1,89 @@
+package cfgbuild
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrefixFallback(t *testing.T) {
+
+	os.Setenv("MY_INT", "42")
+	os.Setenv("MY_STRING", "Nobody expects the Spanish Inquisition!")
+	os.Setenv("MY_BOOL", "tRuE")
+
+	b := Builder[*TestPrefixFallbackParentConfig]{debug: true, PrefixFallback: true}
+
+	cfg, err := b.Build()
+	assert.NoError(t, err)
+
+	assert.NotNil(t, cfg)
+
+	assert.Equal(t, 42, cfg.MyInt)
+	assert.Equal(t, "Nobody expects the Spanish Inquisition!", cfg.MyString)
+	assert.True(t, cfg.MyBool)
+
+	assert.Equal(t, 42, cfg.MyChild.MyInt)
+	assert.Equal(t, "Nobody expects the Spanish Inquisition!", cfg.MyChild.MyString)
+	assert.True(t, cfg.MyChild.MyBool)
+}
+
+func TestNoPrefixFallbackWithoutFlag(t *testing.T) {
+
+	os.Setenv("MY_INT", "42")
+	os.Setenv("MY_STRING", "Nobody expects the Spanish Inquisition!")
+	os.Setenv("MY_BOOL", "tRuE")
+
+	b := Builder[*TestPrefixFallbackParentConfig]{debug: true}
+
+	cfg, err := b.Build()
+	assert.NoError(t, err)
+
+	assert.NotNil(t, cfg)
+
+	assert.Equal(t, 42, cfg.MyInt)
+	assert.Equal(t, "Nobody expects the Spanish Inquisition!", cfg.MyString)
+	assert.True(t, cfg.MyBool)
+
+	assert.Equal(t, 0, cfg.MyChild.MyInt)
+	assert.Equal(t, "", cfg.MyChild.MyString)
+	assert.False(t, cfg.MyChild.MyBool)
+}
+
+func TestPartialPrefixFallback(t *testing.T) {
+
+	os.Setenv("MY_INT", "42")
+	os.Setenv("MY_STRING", "Nobody expects the Spanish Inquisition!")
+	os.Setenv("MY_BOOL", "tRuE")
+
+	os.Setenv("PREFIX_MY_STRING", "Fetch the comfy chair.")
+
+	b := Builder[*TestPrefixFallbackParentConfig]{debug: true, PrefixFallback: true}
+
+	cfg, err := b.Build()
+	assert.NoError(t, err)
+
+	assert.NotNil(t, cfg)
+
+	assert.Equal(t, 42, cfg.MyInt)
+	assert.Equal(t, "Nobody expects the Spanish Inquisition!", cfg.MyString)
+	assert.True(t, cfg.MyBool)
+
+	assert.Equal(t, 42, cfg.MyChild.MyInt)
+	assert.Equal(t, "Fetch the comfy chair.", cfg.MyChild.MyString)
+	assert.True(t, cfg.MyChild.MyBool)
+}
+
+type TestPrefixFallbackParentConfig struct {
+	MyInt    int                           `envvar:"MY_INT"`
+	MyString string                        `envvar:"MY_STRING"`
+	MyBool   bool                          `envvar:"MY_BOOL"`
+	MyChild  TestPrefixFallbackChildConfig `envvar:">,prefix=PREFIX_"`
+}
+
+type TestPrefixFallbackChildConfig struct {
+	MyInt    int    `envvar:"MY_INT"`
+	MyString string `envvar:"MY_STRING"`
+	MyBool   bool   `envvar:"MY_BOOL"`
+}


### PR DESCRIPTION
Add option to allow falling back to non-prefixed env var if the prefixed env var doesn't exist.